### PR TITLE
feat: add AccountExistsEmail template and update user creation logic …

### DIFF
--- a/app/services/email/__init__.py
+++ b/app/services/email/__init__.py
@@ -7,6 +7,7 @@ from app.services.email.types import (
     PasswordResetEmail,
     VerificationEmail,
     WelcomeEmail,
+    AccountExistsEmail,
 )
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "BaseEmail",
     "PasswordResetEmail",
     "WelcomeEmail",
+    "AccountExistsEmail",
     "VerificationEmail",
     "NotificationEmail",
     "send_password_reset_email",

--- a/app/services/email/types/__init__.py
+++ b/app/services/email/types/__init__.py
@@ -2,10 +2,12 @@ from app.services.email.types.notification import NotificationEmail
 from app.services.email.types.password_reset import PasswordResetEmail
 from app.services.email.types.verification import VerificationEmail
 from app.services.email.types.welcome import WelcomeEmail
+from app.services.email.types.account_exists import AccountExistsEmail
 
 __all__ = [
     "PasswordResetEmail",
     "WelcomeEmail",
     "VerificationEmail",
     "NotificationEmail",
+    "AccountExistsEmail",
 ]

--- a/app/services/email/types/account_exists.py
+++ b/app/services/email/types/account_exists.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict
+
+from app.services.email.base import BaseEmail
+
+
+class AccountExistsEmail(BaseEmail):
+    @property
+    def template_name(self) -> str:
+        return "emails/account_exists.html"
+
+    @property
+    def subject(self) -> str:
+        return "Account Already Exists"
+
+    def get_context(self, **kwargs) -> Dict[str, Any]:
+        context = super().get_context(**kwargs)
+        required_fields = ["first_name", "reset_password_url", "login_link"]
+        for field in required_fields:
+            if field not in kwargs:
+                raise ValueError(
+                    f"Missing required field for AccountExistsEmail: {field}"
+                )
+        return context

--- a/app/templates/emails/account_exists.html
+++ b/app/templates/emails/account_exists.html
@@ -1,0 +1,23 @@
+{% extends "emails/base.html" %}
+
+{% block title %}An Account Already Exists{% endblock %}
+
+{% block header_title %}An Account Already Exists{% endblock %}
+
+{% block content %}
+<p>Hello {{ first_name }},</p>
+
+<p>It seems that you already have an account with us. If you forgot your password, you can reset it using the link below:</p>
+
+<div class="highlight" style="background-color: #e6f7ff; color: #0070f3; padding: 15px; border-radius: 6px; margin: 20px 0;">
+    <a href="{{ reset_password_url }}" style="color: #0070f3; text-decoration: none;">Reset your password</a>
+</div>
+
+<p>If you didn't request this email, please ignore it.</p>
+
+{% if login_url %}
+<div style="text-align: center;">
+    <a class="primary-btn" href="{{ login_url }}">Log in to your account</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -3,7 +3,7 @@ ACCESS_TOKEN_NAME = "access_token"  # nosec
 REFRESH_TOKEN_NAME = "refresh_token"  # nosec
 
 USER_NOT_FOUND_ERROR = "User not found"  # nosec
-EMAIL_ALREADY_EXISTS_ERROR = "An account with this email already exists."  # nosec
+EMAIL_ALREADY_EXISTS_ERROR = "If an account with this email already exists, a password reset link has been sent."  # nosec
 INVALID_CREDENTIALS_ERROR = "Invalid credentials"  # nosec
 EMAIL_VERIFICATION_REQUIRED_ERROR = "Email verification required. Please check your email inbox and verify your account."  # nosec
 TWOFA_REQUIRED_ERROR = "2FA token required or invalid"  # nosec


### PR DESCRIPTION
This pull request introduces functionality to handle cases where a user attempts to register with an email that already exists in the system. The changes include adding a new email template and service for notifying users about existing accounts, refreshing database entities after updates, and updating error messages to reflect the new behavior.


[Response]
<img width="927" height="612" alt="Screenshot 2025-07-25 at 5 45 25 PM" src="https://github.com/user-attachments/assets/b382dbb4-4c93-4390-9669-a1d8c17ca0b8" />


[Email]
<img width="1224" height="663" alt="Screenshot 2025-07-25 at 5 44 53 PM" src="https://github.com/user-attachments/assets/0a1cf842-f76c-4ead-845c-e05c94aae72f" />


